### PR TITLE
feat: Chords (multiple non-modifier keys)

### DIFF
--- a/projects/demo/src/app/customize/customize.component.ts
+++ b/projects/demo/src/app/customize/customize.component.ts
@@ -47,6 +47,13 @@ export class CustomizeComponent {
             macKeys: ['meta', 'k']
         },
         {
+            id: 'chord-ca',
+            name: 'Chord C+A',
+            description: 'Demo chord: press C and A together',
+            keys: ['c', 'a'],
+            macKeys: ['c', 'a']
+        },
+        {
             id: 'refresh-data',
             name: 'Refresh Data',
             description: 'Refresh the current page data',

--- a/projects/ngx-keys/README.md
+++ b/projects/ngx-keys/README.md
@@ -132,6 +132,25 @@ this.keyboardService.deactivate('save');
 this.keyboardService.activate('save');
 ```
 
+### Chords (multiple non-modifier keys)
+
+- ngx-keys supports chords composed of multiple non-modifier keys pressed simultaneously (for example `C + A`).
+- When multiple non-modifier keys are physically held down at the same time, the service uses the set of currently pressed keys plus any modifier flags to match registered shortcuts.
+- Example: register a chord with `keys: ['c','a']` and pressing and holding `c` then pressing `a` will trigger the shortcut.
+- Note: Browsers deliver separate keydown events for each physical key; the library maintains a Set of currently-down keys via `keydown`/`keyup` listeners to enable chords. This approach attempts to be robust but can be affected by browser focus changes — ensure tests in your target browsers.
+
+Example registration:
+
+```typescript
+this.keyboardService.register({
+  id: 'chord-ca',
+  keys: ['c', 'a'],
+  macKeys: ['c', 'a'],
+  action: () => console.log('Chord C+A executed'),
+  description: 'Demo chord'
+});
+```
+
 ## API Reference
 
 ### KeyboardShortcuts Service

--- a/projects/ngx-keys/README.md
+++ b/projects/ngx-keys/README.md
@@ -132,25 +132,6 @@ this.keyboardService.deactivate('save');
 this.keyboardService.activate('save');
 ```
 
-### Chords (multiple non-modifier keys)
-
-- ngx-keys supports chords composed of multiple non-modifier keys pressed simultaneously (for example `C + A`).
-- When multiple non-modifier keys are physically held down at the same time, the service uses the set of currently pressed keys plus any modifier flags to match registered shortcuts.
-- Example: register a chord with `keys: ['c','a']` and pressing and holding `c` then pressing `a` will trigger the shortcut.
-- Note: Browsers deliver separate keydown events for each physical key; the library maintains a Set of currently-down keys via `keydown`/`keyup` listeners to enable chords. This approach attempts to be robust but can be affected by browser focus changes — ensure tests in your target browsers.
-
-Example registration:
-
-```typescript
-this.keyboardService.register({
-  id: 'chord-ca',
-  keys: ['c', 'a'],
-  macKeys: ['c', 'a'],
-  action: () => console.log('Chord C+A executed'),
-  description: 'Demo chord'
-});
-```
-
 ## API Reference
 
 ### KeyboardShortcuts Service
@@ -440,6 +421,25 @@ export class MyComponent {
     }
   }
 }
+```
+
+### Chords (multiple non-modifier keys)
+
+- ngx-keys supports chords composed of multiple non-modifier keys pressed simultaneously (for example `C + A`).
+- When multiple non-modifier keys are physically held down at the same time, the service uses the set of currently pressed keys plus any modifier flags to match registered shortcuts.
+- Example: register a chord with `keys: ['c','a']` and pressing and holding `c` then pressing `a` will trigger the shortcut.
+- Note: Browsers deliver separate keydown events for each physical key; the library maintains a Set of currently-down keys via `keydown`/`keyup` listeners to enable chords. This approach attempts to be robust but can be affected by browser focus changes — ensure tests in your target browsers.
+
+Example registration:
+
+```typescript
+this.keyboardService.register({
+  id: 'chord-ca',
+  keys: ['c', 'a'],
+  macKeys: ['c', 'a'],
+  action: () => console.log('Chord C+A executed'),
+  description: 'Demo chord'
+});
 ```
 
 ## Building

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -338,6 +338,32 @@ describe('KeyboardShortcuts', () => {
       expect(chordAction).not.toHaveBeenCalled();
     });
 
+    it('should clear currently-down keys and prevent stale chord matches', () => {
+      const chordAction = jasmine.createSpy('chordActionClear');
+      service.register({
+        id: 'chord-clear',
+        keys: ['m', 'n'],
+        macKeys: ['m', 'n'],
+        action: chordAction,
+        description: 'Chord M+N'
+      });
+
+      const testableService = service as any;
+
+      // Simulate m down
+      const eventM = new KeyboardEvent('keydown', { key: 'm' });
+      testableService.testHandleKeydown(eventM);
+
+      // Now simulate window blur/visibility change by calling the clear method
+      testableService.clearCurrentlyDownKeys();
+
+      // Simulate n down — chord should not trigger because the state was cleared
+      const eventN = new KeyboardEvent('keydown', { key: 'n' });
+      testableService.testHandleKeydown(eventN);
+
+      expect(chordAction).not.toHaveBeenCalled();
+    });
+
     it('should parse multiple modifier keys', () => {
       const event = new KeyboardEvent('keydown', {
         ctrlKey: true,

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -295,6 +295,49 @@ describe('KeyboardShortcuts', () => {
       expect(pressedKeys).toEqual(['ctrl', 's']);
     });
 
+    it('should detect and match a chord of two non-modifier keys', () => {
+      // Register a chord shortcut composed of two non-modifier keys: 'c' + 'a'
+      const chordAction = jasmine.createSpy('chordAction');
+      service.register({
+        id: 'chord-ca',
+        keys: ['c', 'a'],
+        macKeys: ['c', 'a'],
+        action: chordAction,
+        description: 'Chord C+A'
+      });
+
+      const testableService = service as any;
+
+      // Simulate keydown for 'c'
+      const eventC = new KeyboardEvent('keydown', { key: 'c' });
+      testableService.testHandleKeydown(eventC);
+
+      // Simulate keydown for 'a' while 'c' is still down
+      const eventA = new KeyboardEvent('keydown', { key: 'a' });
+      testableService.testHandleKeydown(eventA);
+
+      // The chord action should have been executed when the second key was pressed
+      expect(chordAction).toHaveBeenCalled();
+    });
+
+    it('should not falsely match chord when only one key is pressed', () => {
+      const chordAction = jasmine.createSpy('chordAction2');
+      service.register({
+        id: 'chord-xy',
+        keys: ['x', 'y'],
+        macKeys: ['x', 'y'],
+        action: chordAction,
+        description: 'Chord X+Y'
+      });
+
+      const testableService = service as any;
+      const eventX = new KeyboardEvent('keydown', { key: 'x' });
+      testableService.testHandleKeydown(eventX);
+
+      // Only one key down - should not trigger
+      expect(chordAction).not.toHaveBeenCalled();
+    });
+
     it('should parse multiple modifier keys', () => {
       const event = new KeyboardEvent('keydown', {
         ctrlKey: true,

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -486,42 +486,32 @@ describe('KeyboardShortcuts', () => {
   });
 
   describe('Key Matching Logic', () => {
-    let testableService: any;
-
-    beforeEach(() => {
-      testableService = service as any;
-    });
 
     it('should correctly parse pressed keys from keyboard event', () => {
-      const event = new KeyboardEvent('keydown', {
-        ctrlKey: true,
-        key: 's'
-      });
+      const event = KeyboardEvents.ctrlS();
 
-      const pressedKeys = testableService.testGetPressedKeys(event);
+      const pressedKeys = service.testGetPressedKeys(event);
       expect(pressedKeys).toEqual(['ctrl', 's']);
     });
 
     it('should detect and match a chord of two non-modifier keys', () => {
-      // Register a chord shortcut composed of two non-modifier keys: 'c' + 'a'
+      // Register a chord shortcut using our utility
       const chordAction = jasmine.createSpy('chordAction');
-      service.register({
+      service.register(createMockShortcut({
         id: 'chord-ca',
         keys: ['c', 'a'],
         macKeys: ['c', 'a'],
         action: chordAction,
         description: 'Chord C+A'
-      });
+      }));
 
-      const testableService = service as any;
-
-      // Simulate keydown for 'c'
-      const eventC = new KeyboardEvent('keydown', { key: 'c' });
-      testableService.testHandleKeydown(eventC);
+      // Simulate keydown for 'c' using our utility
+      const eventC = createKeyboardEvent({ key: 'c' });
+      service.testHandleKeydown(eventC);
 
       // Simulate keydown for 'a' while 'c' is still down
-      const eventA = new KeyboardEvent('keydown', { key: 'a' });
-      testableService.testHandleKeydown(eventA);
+      const eventA = createKeyboardEvent({ key: 'a' });
+      service.testHandleKeydown(eventA);
 
       // The chord action should have been executed when the second key was pressed
       expect(chordAction).toHaveBeenCalled();
@@ -529,17 +519,16 @@ describe('KeyboardShortcuts', () => {
 
     it('should not falsely match chord when only one key is pressed', () => {
       const chordAction = jasmine.createSpy('chordAction2');
-      service.register({
+      service.register(createMockShortcut({
         id: 'chord-xy',
         keys: ['x', 'y'],
         macKeys: ['x', 'y'],
         action: chordAction,
         description: 'Chord X+Y'
-      });
+      }));
 
-      const testableService = service as any;
-      const eventX = new KeyboardEvent('keydown', { key: 'x' });
-      testableService.testHandleKeydown(eventX);
+      const eventX = createKeyboardEvent({ key: 'x' });
+      service.testHandleKeydown(eventX);
 
       // Only one key down - should not trigger
       expect(chordAction).not.toHaveBeenCalled();
@@ -547,59 +536,143 @@ describe('KeyboardShortcuts', () => {
 
     it('should clear currently-down keys and prevent stale chord matches', () => {
       const chordAction = jasmine.createSpy('chordActionClear');
-      service.register({
+      service.register(createMockShortcut({
         id: 'chord-clear',
         keys: ['m', 'n'],
         macKeys: ['m', 'n'],
         action: chordAction,
         description: 'Chord M+N'
-      });
+      }));
 
-      const testableService = service as any;
-
-      // Simulate m down
-      const eventM = new KeyboardEvent('keydown', { key: 'm' });
-      testableService.testHandleKeydown(eventM);
+      // Simulate m down using our utility
+      const eventM = createKeyboardEvent({ key: 'm' });
+      service.testHandleKeydown(eventM);
 
       // Now simulate window blur/visibility change by calling the clear method
-      testableService.clearCurrentlyDownKeys();
+      service.clearCurrentlyDownKeys();
 
       // Simulate n down — chord should not trigger because the state was cleared
-      const eventN = new KeyboardEvent('keydown', { key: 'n' });
-      testableService.testHandleKeydown(eventN);
+      const eventN = createKeyboardEvent({ key: 'n' });
+      service.testHandleKeydown(eventN);
 
       expect(chordAction).not.toHaveBeenCalled();
     });
 
-    it('should parse multiple modifier keys', () => {
-      const event = new KeyboardEvent('keydown', {
-        ctrlKey: true,
-        altKey: true,
-        shiftKey: true,
-        metaKey: true,
-        key: 'a'
-      });
+    it('should handle chord with three non-modifier keys', () => {
+      const chordAction = jasmine.createSpy('tripleChordAction');
+      service.register(createMockShortcut({
+        id: 'chord-abc',
+        keys: ['a', 'b', 'c'],
+        macKeys: ['a', 'b', 'c'],
+        action: chordAction,
+        description: 'Chord A+B+C'
+      }));
 
-      const pressedKeys = testableService.testGetPressedKeys(event);
+      // Press all three keys in sequence
+      service.testHandleKeydown(createKeyboardEvent({ key: 'a' }));
+      service.testHandleKeydown(createKeyboardEvent({ key: 'b' }));
+      service.testHandleKeydown(createKeyboardEvent({ key: 'c' }));
+
+      expect(chordAction).toHaveBeenCalled();
+    });
+
+    it('should handle chord with modifiers and non-modifier keys combined', () => {
+      const chordAction = jasmine.createSpy('modifierChordAction');
+      service.register(createMockShortcut({
+        id: 'chord-ctrl-ab',
+        keys: ['ctrl', 'a', 'b'],
+        macKeys: ['meta', 'a', 'b'],
+        action: chordAction,
+        description: 'Chord Ctrl+A+B'
+      }));
+
+      // Press ctrl, then a, then b
+      service.testHandleKeydown(createKeyboardEvent({ key: 'a', ctrlKey: true }));
+      service.testHandleKeydown(createKeyboardEvent({ key: 'b', ctrlKey: true }));
+
+      expect(chordAction).toHaveBeenCalled();
+    });
+
+    it('should not trigger chord when keys are pressed in wrong combination', () => {
+      const chordAction = jasmine.createSpy('wrongOrderAction');
+      service.register(createMockShortcut({
+        id: 'chord-precise',
+        keys: ['p', 'q'],
+        macKeys: ['p', 'q'],
+        action: chordAction,
+        description: 'Chord P+Q'
+      }));
+
+      // Press only p, then release without pressing q
+      service.testHandleKeydown(createKeyboardEvent({ key: 'p' }));
+      // Simulate some other key being pressed instead
+      service.testHandleKeydown(createKeyboardEvent({ key: 'r' }));
+
+      expect(chordAction).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple different chords without interference', () => {
+      const chordAction1 = jasmine.createSpy('chord1Action');
+      const chordAction2 = jasmine.createSpy('chord2Action');
+      
+      service.register(createMockShortcut({
+        id: 'chord-first',
+        keys: ['j', 'k'],
+        macKeys: ['j', 'k'],
+        action: chordAction1,
+        description: 'Chord J+K'
+      }));
+
+      service.register(createMockShortcut({
+        id: 'chord-second',
+        keys: ['l', 'm'],
+        macKeys: ['l', 'm'],
+        action: chordAction2,
+        description: 'Chord L+M'
+      }));
+
+      // Trigger first chord
+      service.testHandleKeydown(createKeyboardEvent({ key: 'j' }));
+      service.testHandleKeydown(createKeyboardEvent({ key: 'k' }));
+
+      expect(chordAction1).toHaveBeenCalled();
+      expect(chordAction2).not.toHaveBeenCalled();
+
+      // Clear currently pressed keys to ensure clean state for second chord
+      service.clearCurrentlyDownKeys();
+      
+      // Reset spy calls and trigger second chord
+      chordAction1.calls.reset();
+      chordAction2.calls.reset();
+
+      service.testHandleKeydown(createKeyboardEvent({ key: 'l' }));
+      service.testHandleKeydown(createKeyboardEvent({ key: 'm' }));
+
+      expect(chordAction1).not.toHaveBeenCalled();
+      expect(chordAction2).toHaveBeenCalled();
+    });
+
+    it('should parse multiple modifier keys', () => {
+      const event = KeyboardEvents.allModifiers('a');
+
+      const pressedKeys = service.testGetPressedKeys(event);
       expect(pressedKeys).toEqual(['ctrl', 'alt', 'shift', 'meta', 'a']);
     });
 
     it('should ignore modifier keys as main key', () => {
-      const event = new KeyboardEvent('keydown', {
+      const event = createKeyboardEvent({
         ctrlKey: true,
         key: 'control'
       });
 
-      const pressedKeys = testableService.testGetPressedKeys(event);
+      const pressedKeys = service.testGetPressedKeys(event);
       expect(pressedKeys).toEqual(['ctrl']);
     });
 
     it('should handle special keys', () => {
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter'
-      });
+      const event = KeyboardEvents.enter();
 
-      const pressedKeys = testableService.testGetPressedKeys(event);
+      const pressedKeys = service.testGetPressedKeys(event);
       expect(pressedKeys).toEqual(['enter']);
     });
 
@@ -607,35 +680,35 @@ describe('KeyboardShortcuts', () => {
       const pressedKeys = ['ctrl', 's'];
       const targetKeys = ['ctrl', 's'];
 
-      expect(testableService.testKeysMatch(pressedKeys, targetKeys)).toBe(true);
+      expect(service.testKeysMatch(pressedKeys, targetKeys)).toBe(true);
     });
 
     it('should not match different key combinations', () => {
       const pressedKeys = ['ctrl', 's'];
       const targetKeys = ['ctrl', 'c'];
 
-      expect(testableService.testKeysMatch(pressedKeys, targetKeys)).toBe(false);
+      expect(service.testKeysMatch(pressedKeys, targetKeys)).toBe(false);
     });
 
     it('should not match different lengths', () => {
       const pressedKeys = ['ctrl', 's'];
       const targetKeys = ['ctrl', 'shift', 's'];
 
-      expect(testableService.testKeysMatch(pressedKeys, targetKeys)).toBe(false);
+      expect(service.testKeysMatch(pressedKeys, targetKeys)).toBe(false);
     });
 
     it('should handle case insensitive key matching', () => {
       const pressedKeys = ['ctrl', 'S'];
       const targetKeys = ['ctrl', 's'];
 
-      expect(testableService.testKeysMatch(pressedKeys, targetKeys)).toBe(true);
+      expect(service.testKeysMatch(pressedKeys, targetKeys)).toBe(true);
     });
 
     it('should match keys regardless of order', () => {
       const pressedKeys = ['s', 'ctrl'];
       const targetKeys = ['ctrl', 's'];
 
-      expect(testableService.testKeysMatch(pressedKeys, targetKeys)).toBe(true);
+      expect(service.testKeysMatch(pressedKeys, targetKeys)).toBe(true);
     });
   });
 


### PR DESCRIPTION
This pull request adds support for keyboard shortcut "chords" (combinations of multiple non-modifier keys pressed simultaneously) to the `ngx-keys` library. It introduces a robust mechanism for tracking currently pressed keys, updates the event handling logic to support chords, and provides comprehensive tests and documentation for this new feature.

# Chord (multi-key) shortcut support

* Added tracking of currently pressed non-modifier keys via a `currentlyDownKeys` set, updated on `keydown`/`keyup` events, allowing detection of chords like `['c', 'a']` or `['a', 'b', 'c']` (`projects/ngx-keys/src/lib/keyboard-shortcuts.ts`) [[1]](diffhunk://#diff-bdd2db0414e22f5d13bb915b764658328060ed7be4bc0fbc253f8422f8197067R58-R66) [[2]](diffhunk://#diff-bdd2db0414e22f5d13bb915b764658328060ed7be4bc0fbc253f8422f8197067R398-R406) [[3]](diffhunk://#diff-bdd2db0414e22f5d13bb915b764658328060ed7be4bc0fbc253f8422f8197067R416-R430) [[4]](diffhunk://#diff-bdd2db0414e22f5d13bb915b764658328060ed7be4bc0fbc253f8422f8197067R454-R558).
* Updated the logic in `handleKeydown` to use the set of currently pressed keys for shortcut matching, enabling robust detection of multiple-key chords and combinations with modifiers (`projects/ngx-keys/src/lib/keyboard-shortcuts.ts`) [[1]](diffhunk://#diff-bdd2db0414e22f5d13bb915b764658328060ed7be4bc0fbc253f8422f8197067R416-R430) [[2]](diffhunk://#diff-bdd2db0414e22f5d13bb915b764658328060ed7be4bc0fbc253f8422f8197067R454-R558).
* Enhanced the `keysMatch` method to support set-based comparison, ensuring that order does not matter and that chords are matched accurately (`projects/ngx-keys/src/lib/keyboard-shortcuts.ts`).

# Event handling and state management improvements

* Added listeners for `keyup`, `blur`, and `visibilitychange` events to ensure the internal state of pressed keys is always accurate and cleared when the window loses focus, preventing stale chord matches.

# Documentation and usage examples

* Updated the README to document chord support, explain browser event handling, and provide example registration code for multi-key shortcuts (`projects/ngx-keys/README.md`).
* Added a demo chord shortcut (`chord-ca`) in the `CustomizeComponent` to illustrate usage (`projects/demo/src/app/customize/customize.component.ts`).

# Testing

* Added comprehensive unit tests for chord detection, including various scenarios: two-key, three-key, chords with modifiers, non-chord presses, state clearing, and multiple chords without interference.