### PR TITLE
refactor: replace global document with injected document

### DIFF
--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -1,4 +1,3 @@
-import { KeyboardShortcuts } from './keyboard-shortcuts';
 import { KeyboardShortcut } from './keyboard-shortcut.interface';
 import { KeyboardShortcutsErrors } from './keyboard-shortcuts.errors';
 import * as ngCore from '@angular/core';
@@ -12,7 +11,6 @@ import {
   TestKeyboardShortcutsWithFakeDestruct,
   TestObservables,
   createMultiStepMockShortcut,
-  DestructGroupService,
 } from './test-utils';
 import { TestBed } from '@angular/core/testing';
 
@@ -35,7 +33,6 @@ describe('KeyboardShortcuts', () => {
         ngCore.provideZonelessChangeDetection(),
         TestableKeyboardShortcuts,
         TestKeyboardShortcutsWithFakeDestruct,
-        DestructGroupService,
       ],
     });
     service = TestBed.inject(TestableKeyboardShortcuts);
@@ -336,7 +333,7 @@ describe('KeyboardShortcuts', () => {
 
       it('should unregister group when activeUntil is "destruct" by using an overridden setupActiveUntil', () => {
         const mockAction = jasmine.createSpy('mockAction');
-        const localService = TestBed.inject(DestructGroupService);
+        const localService = TestBed.inject(TestKeyboardShortcutsWithFakeDestruct);
 
         const shortcuts = [
           {
@@ -351,7 +348,7 @@ describe('KeyboardShortcuts', () => {
         localService.registerGroup('group-destruct', shortcuts, 'destruct' as any);
         expect(localService.isGroupRegistered('group-destruct')).toBe(true);
 
-        localService.fakeRef.trigger();
+        localService.fakeDestroyRef.trigger();
         expect(localService.isGroupRegistered('group-destruct')).toBe(false);
       });
 

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -11,7 +11,6 @@ import {
   KeyboardEvents,
   TestKeyboardShortcutsWithFakeDestruct,
   TestObservables,
-  NonBrowserKeyboardShortcuts,
   createMultiStepMockShortcut,
   DestructGroupService,
 } from './test-utils';
@@ -35,7 +34,6 @@ describe('KeyboardShortcuts', () => {
       providers: [
         ngCore.provideZonelessChangeDetection(),
         TestableKeyboardShortcuts,
-        NonBrowserKeyboardShortcuts,
         TestKeyboardShortcutsWithFakeDestruct,
         DestructGroupService,
       ],
@@ -730,7 +728,7 @@ describe('KeyboardShortcuts', () => {
       });
       service.register(shortcut);
 
-      // Mock both the platform detection AND isBrowser check
+      // Mock the platform detection check
       spyOn(service, 'testIsMacPlatform').and.returnValue(true);
       // Override the isMacPlatform method call in handleKeydown
       spyOn(service as any, 'isMacPlatform').and.returnValue(true);
@@ -890,7 +888,7 @@ describe('KeyboardShortcuts', () => {
 
   describe('Browser Environment Handling', () => {
     it('should handle non-browser environment gracefully', () => {
-      const localService = TestBed.inject(NonBrowserKeyboardShortcuts);
+      const localService = TestBed.inject(TestableKeyboardShortcuts);
       expect(() => localService).not.toThrow();
     });
   });

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -883,13 +883,6 @@ describe('KeyboardShortcuts', () => {
     });
   });
 
-  describe('Browser Environment Handling', () => {
-    it('should handle non-browser environment gracefully', () => {
-      const localService = TestBed.inject(TestableKeyboardShortcuts);
-      expect(() => localService).not.toThrow();
-    });
-  });
-
   describe('ReadOnly Maps', () => {
     it('should return readonly maps for shortcuts and groups', () => {
       const shortcuts = service.getShortcuts();

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.ts
@@ -1,4 +1,12 @@
-import { Injectable, OnDestroy, PLATFORM_ID, inject, signal, computed } from '@angular/core';
+import {
+  Injectable,
+  OnDestroy,
+  PLATFORM_ID,
+  inject,
+  signal,
+  computed,
+  DOCUMENT,
+} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { KeyboardShortcut, KeyboardShortcutGroup, KeyboardShortcutUI } from './keyboard-shortcut.interface';
 import { KeyboardShortcutsErrorFactory } from './keyboard-shortcuts.errors';
@@ -7,6 +15,8 @@ import { KeyboardShortcutsErrorFactory } from './keyboard-shortcuts.errors';
   providedIn: 'root'
 })
 export class KeyboardShortcuts implements OnDestroy {
+  private readonly document = inject(DOCUMENT);
+  private readonly window = this.document.defaultView;
   private readonly shortcuts = new Map<string, KeyboardShortcut>();
   private readonly groups = new Map<string, KeyboardShortcutGroup>();
   private readonly activeShortcuts = new Set<string>();
@@ -63,7 +73,7 @@ export class KeyboardShortcuts implements OnDestroy {
       const platformId = inject(PLATFORM_ID);
       this.isBrowser = isPlatformBrowser(platformId);
     } catch {
-      // Fallback for testing - assume browser environment
+      // Fallback for testing, use `window` & `document` directly - assume browser environment
       this.isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
     }
 
@@ -377,7 +387,7 @@ export class KeyboardShortcuts implements OnDestroy {
       return;
     }
     
-    document.addEventListener('keydown', this.keydownListener, { passive: false });
+    this.document.addEventListener('keydown', this.keydownListener, { passive: false });
     this.isListening = true;
   }
 
@@ -386,7 +396,7 @@ export class KeyboardShortcuts implements OnDestroy {
       return;
     }
     
-    document.removeEventListener('keydown', this.keydownListener);
+    this.document.removeEventListener('keydown', this.keydownListener);
     this.isListening = false;
   }
 
@@ -445,6 +455,6 @@ export class KeyboardShortcuts implements OnDestroy {
   }
 
   protected isMacPlatform(): boolean {
-    return this.isBrowser && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+    return this.isBrowser && /Mac|iPod|iPhone|iPad/.test(this.window?.navigator.platform ?? '');
   }
 }

--- a/projects/ngx-keys/src/lib/test-utils.ts
+++ b/projects/ngx-keys/src/lib/test-utils.ts
@@ -252,30 +252,6 @@ export class TestKeyboardShortcutsWithFakeDestruct extends KeyboardShortcuts {
   }
 }
 
-@Injectable()
-export class DestructGroupService extends KeyboardShortcuts {
-  public fakeRef = {
-    cb: null as (() => void) | null,
-    onDestroy(fn: () => void) {
-      this.cb = fn;
-    },
-    trigger() {
-      if (this.cb) this.cb();
-    },
-  };
-  constructor() {
-    super();
-    (this as any).isListening = false;
-  }
-  protected override setupActiveUntil(activeUntil: any, unregister: () => void) {
-    if (activeUntil === 'destruct') {
-      this.fakeRef.onDestroy(unregister);
-      return;
-    }
-    return super.setupActiveUntil(activeUntil, unregister);
-  }
-}
-
 /**
  * Observable helpers for testing activeUntil with observables
  */

--- a/projects/ngx-keys/src/lib/test-utils.ts
+++ b/projects/ngx-keys/src/lib/test-utils.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { KeyboardShortcuts } from './keyboard-shortcuts';
 import { KeyboardShortcut } from './keyboard-shortcut.interface';
 import { Observable, of } from 'rxjs';
@@ -38,6 +39,7 @@ export interface MockShortcutConfig {
 /**
  * Creates a testable KeyboardShortcuts service instance with exposed protected methods
  */
+@Injectable()
 export class TestableKeyboardShortcuts extends KeyboardShortcuts {
   constructor() {
     super();
@@ -233,6 +235,7 @@ export function createFakeDestroyRef(): FakeDestroyRef {
 /**
  * Test service that extends KeyboardShortcuts to override activeUntil handling
  */
+@Injectable()
 export class TestKeyboardShortcutsWithFakeDestruct extends KeyboardShortcuts {
   public fakeDestroyRef = createFakeDestroyRef();
 
@@ -245,6 +248,31 @@ export class TestKeyboardShortcutsWithFakeDestruct extends KeyboardShortcuts {
   protected override setupActiveUntil(activeUntil: any, unregister: () => void): void {
     if (activeUntil === 'destruct') {
       this.fakeDestroyRef.onDestroy(unregister);
+      return;
+    }
+    return super.setupActiveUntil(activeUntil, unregister);
+  }
+}
+
+@Injectable()
+export class DestructGroupService extends KeyboardShortcuts {
+  public fakeRef = {
+    cb: null as (() => void) | null,
+    onDestroy(fn: () => void) {
+      this.cb = fn;
+    },
+    trigger() {
+      if (this.cb) this.cb();
+    },
+  };
+  constructor() {
+    super();
+    (this as any).isBrowser = true;
+    (this as any).isListening = false;
+  }
+  protected override setupActiveUntil(activeUntil: any, unregister: () => void) {
+    if (activeUntil === 'destruct') {
+      this.fakeRef.onDestroy(unregister);
       return;
     }
     return super.setupActiveUntil(activeUntil, unregister);
@@ -269,6 +297,7 @@ export const TestObservables = {
 /**
  * Non-browser environment test service
  */
+@Injectable()
 export class NonBrowserKeyboardShortcuts extends KeyboardShortcuts {
   constructor() {
     super();

--- a/projects/ngx-keys/src/lib/test-utils.ts
+++ b/projects/ngx-keys/src/lib/test-utils.ts
@@ -44,7 +44,6 @@ export class TestableKeyboardShortcuts extends KeyboardShortcuts {
   constructor() {
     super();
     // Override platform detection for testing
-    (this as any).isBrowser = true;
     (this as any).isListening = false;
   }
 
@@ -241,7 +240,6 @@ export class TestKeyboardShortcutsWithFakeDestruct extends KeyboardShortcuts {
 
   constructor() {
     super();
-    (this as any).isBrowser = true;
     (this as any).isListening = false;
   }
 
@@ -267,7 +265,6 @@ export class DestructGroupService extends KeyboardShortcuts {
   };
   constructor() {
     super();
-    (this as any).isBrowser = true;
     (this as any).isListening = false;
   }
   protected override setupActiveUntil(activeUntil: any, unregister: () => void) {
@@ -293,14 +290,3 @@ export const TestObservables = {
    */
   immediateTrigger: (): Observable<boolean> => of(true)
 };
-
-/**
- * Non-browser environment test service
- */
-@Injectable()
-export class NonBrowserKeyboardShortcuts extends KeyboardShortcuts {
-  constructor() {
-    super();
-    (this as any).isBrowser = false;
-  }
-}


### PR DESCRIPTION
This MR covers some changes for improved SSR support. Closes #8

**Code changes:**
- Uses `inject(DOCUMENT)` as `this.document` instead of directly using the global `document` object, which is not available in server contexts.
- Uses `this.document.defaultView` as `this.window` instead of directly using the global `window` object, which is not available in server contexts.
- Replaces `navigator` with `this.window.navigator` and added a fallback value of an empty string. The fallback value is added just in case some modern browser decides to drop support for this API, which has been marked as deprecated for a long time.
- Removed usage of the `isBrowser` variable from all places since it is not needed anymore, with `afterNextRender` enforcing client-side usage.

**Testing changes:**
- Since we are now using Angular DI for injecting `DOCUMENT`, the tests need to be updated to handle the injection context correctly. This can currently only be done by [setting up providers using `TestBed`](https://angular.dev/guide/testing/services#testing-services-with-the-testbed).
- `TestBed` depends on `zone.js` by default, which does not exist in this project. To opt into zoneless testing, we need to provide `provideZonelessChangeDetection()` to `TestBed`.
- `TestBed` can only be initiated once per `describe`/`beforeEach` block, so all three Testable*Class were moved into a single TestBed for simplicity. For large test suites, we should consider splitting the current test suite into three separate test suites.
- There was a CLI console warning by Jasmine, that in future versions of Angular, TestBed will only accept classes that are also marked with `@Injectable`. I have made this change as well.
- Minor cleanup: ~For consistency, I moved `DestructGroupService` from being inline in the spec file and into the utils file.~ As noted in a review comment, `DestructGroupService` is very similar to `TestKeyboardShortcutsWithFakeDestruct` and has now been replaced by it.
- Removed `NonBrowserKeyboardShortcuts` since its only purpose was to manage the `isBrowser` variable, which does not exist anymore.
- Removed outdated test for `Browser Environment Handling`, since all logic has been moved into an `afterNextRender` block.