### PR TITLE
chore: add prettier to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "ngx-keys",
-  "version": "0.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-keys",
-      "version": "0.0.0",
+      "version": "1.0.1",
+      "license": "0BSD",
       "dependencies": {
         "@angular/common": "^20.2.0",
         "@angular/compiler": "^20.2.0",
@@ -29,6 +30,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "ng-packagr": "^20.2.0",
+        "prettier": "^3.6.2",
         "typescript": "~5.9.2"
       }
     },
@@ -8525,6 +8527,22 @@
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proc-log": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "ng-packagr": "^20.2.0",
+    "prettier": "^3.6.2",
     "typescript": "~5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "format": "./node_modules/.bin/prettier --write \"./**/*.{ts,html,scss,css,json,md}\"",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
The existing code base appears to be formatted with prettier v2.x, which has a different default config. Adding this to the dev dependencies ensures consistency for contributors. Editors like VS Code will now pick up the exact version pinned in the lock file.

Additionally, the latest ngx-keys version and license appear to have been added automatically to the package-lock file, so I will leave them as is.