### PR TITLE
feat: Event Filtering

### DIFF
--- a/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
@@ -45,6 +45,24 @@ export interface KeyboardShortcutGroup {
   id: string;
   shortcuts: KeyboardShortcut[];
   active: boolean;
+  /**
+   * Optional filter function for this entire group.
+   * If provided, this filter is evaluated AFTER global filters but BEFORE individual shortcut filters.
+   * The filter hierarchy is: Global filters → Group filter → Individual shortcut filter.
+   * All applicable filters must return true for a shortcut to execute.
+   * 
+   * @param event - The keyboard event to evaluate
+   * @returns `true` to allow shortcuts in this group, `false` to ignore the event
+   * 
+   * @example
+   * ```typescript
+   * // Modal shortcuts group that only works when modal is active
+   * keyboardService.registerGroup('modal-shortcuts', shortcuts, {
+   *   filter: (event) => !!document.querySelector('.modal.active')
+   * });
+   * ```
+   */
+  filter?: KeyboardShortcutFilter;
 }
 
 /**
@@ -67,6 +85,21 @@ export interface KeyboardShortcutGroup {
  * ```
  */
 export type KeyboardShortcutFilter = (event: KeyboardEvent) => boolean;
+
+/**
+ * Options for registering a group of keyboard shortcuts
+ */
+export interface KeyboardShortcutGroupOptions {
+  /**
+   * Optional filter function for the entire group.
+   * This filter is evaluated after global filters but before individual shortcut filters.
+   */
+  filter?: KeyboardShortcutFilter;
+  /**
+   * Optional lifecycle management for automatic cleanup
+   */
+  activeUntil?: KeyboardShortcutActiveUntil;
+}
 
 /**
  * Interface for keyboard shortcut data optimized for UI display

--- a/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
@@ -27,6 +27,27 @@ export interface KeyboardShortcutGroup {
 }
 
 /**
+ * Filter function type for determining whether a keyboard event should be processed.
+ * Return `true` to process the event (allow shortcuts), `false` to ignore it.
+ * 
+ * @param event - The keyboard event to evaluate
+ * @returns `true` to allow shortcuts, `false` to ignore the event
+ * 
+ * @example
+ * ```typescript
+ * // Ignore shortcuts when typing in form elements
+ * const inputFilter: KeyboardShortcutFilter = (event) => {
+ *   const target = event.target as HTMLElement;
+ *   const tagName = target?.tagName?.toLowerCase();
+ *   return !['input', 'textarea', 'select'].includes(tagName) && !target?.isContentEditable;
+ * };
+ * 
+ * keyboardService.setFilter(inputFilter);
+ * ```
+ */
+export type KeyboardShortcutFilter = (event: KeyboardEvent) => boolean;
+
+/**
  * Interface for keyboard shortcut data optimized for UI display
  */
 export interface KeyboardShortcutUI {

--- a/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
@@ -17,7 +17,28 @@ export interface KeyboardShortcut {
   macSteps?: KeyStep[];
   action: () => void;
   description: string;
-  activeUntil?: KeyboardShortcutActiveUntil
+  activeUntil?: KeyboardShortcutActiveUntil;
+  /**
+   * Optional filter function for this specific shortcut.
+   * If provided, this filter is evaluated AFTER global filters.
+   * Both global filters AND this filter must return true for the shortcut to execute.
+   * 
+   * @param event - The keyboard event to evaluate
+   * @returns `true` to allow this shortcut, `false` to ignore the event
+   * 
+   * @example
+   * ```typescript
+   * // This shortcut works everywhere, even bypassing global input filters
+   * {
+   *   id: 'emergency-save',
+   *   keys: ['ctrl', 'shift', 's'],
+   *   action: () => this.emergencySave(),
+   *   filter: () => true, // Always allow
+   *   description: 'Emergency save (works in inputs)'
+   * }
+   * ```
+   */
+  filter?: KeyboardShortcutFilter;
 }
 
 export interface KeyboardShortcutGroup {

--- a/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
@@ -80,8 +80,7 @@ export interface KeyboardShortcutGroup {
  *   const tagName = target?.tagName?.toLowerCase();
  *   return !['input', 'textarea', 'select'].includes(tagName) && !target?.isContentEditable;
  * };
- * 
- * keyboardService.setFilter(inputFilter);
+ * // keyboardService.addFilter('forms', inputFilter);
  * ```
  */
 export type KeyboardShortcutFilter = (event: KeyboardEvent) => boolean;

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.spec.ts
@@ -484,8 +484,8 @@ describe('KeyboardShortcuts', () => {
     it('should correctly parse pressed keys from keyboard event', () => {
       const event = KeyboardEvents.ctrlS();
 
-      const pressedKeys = service.testGetPressedKeys(event);
-      expect(pressedKeys).toEqual(['ctrl', 's']);
+  const pressedKeys = service.testGetPressedKeys(event);
+  expect(pressedKeys).toEqual(new Set(['ctrl', 's']));
     });
 
     it('should detect and match a chord of two non-modifier keys', () => {
@@ -649,8 +649,8 @@ describe('KeyboardShortcuts', () => {
     it('should parse multiple modifier keys', () => {
       const event = KeyboardEvents.allModifiers('a');
 
-      const pressedKeys = service.testGetPressedKeys(event);
-      expect(pressedKeys).toEqual(['ctrl', 'alt', 'shift', 'meta', 'a']);
+  const pressedKeys = service.testGetPressedKeys(event);
+  expect(pressedKeys).toEqual(new Set(['ctrl', 'alt', 'shift', 'meta', 'a']));
     });
 
     it('should ignore modifier keys as main key', () => {
@@ -659,15 +659,15 @@ describe('KeyboardShortcuts', () => {
         key: 'control'
       });
 
-      const pressedKeys = service.testGetPressedKeys(event);
-      expect(pressedKeys).toEqual(['ctrl']);
+  const pressedKeys = service.testGetPressedKeys(event);
+  expect(pressedKeys).toEqual(new Set(['ctrl']));
     });
 
     it('should handle special keys', () => {
       const event = KeyboardEvents.enter();
 
-      const pressedKeys = service.testGetPressedKeys(event);
-      expect(pressedKeys).toEqual(['enter']);
+  const pressedKeys = service.testGetPressedKeys(event);
+  expect(pressedKeys).toEqual(new Set(['enter']));
     });
 
     it('should match keys correctly', () => {

--- a/projects/ngx-keys/src/lib/test-utils.ts
+++ b/projects/ngx-keys/src/lib/test-utils.ts
@@ -52,8 +52,10 @@ export class TestableKeyboardShortcuts extends KeyboardShortcuts {
 
   // Make protected methods public for testing
   public testHandleKeydown = this.handleKeydown.bind(this);
-  public testGetPressedKeys = (event: KeyboardEvent) => this.getPressedKeys(event);
-  public testKeysMatch = (pressed: string[], target: string[]) => this.keysMatch(pressed, target);
+  // Expose the canonical Set-based API for pressed keys to tests
+  public testGetPressedKeys = (event: KeyboardEvent): Set<string> => this.getPressedKeys(event);
+  // KeysMatch accepts either a Set or an array; keep the helper flexible for tests
+  public testKeysMatch = (pressed: Set<string> | string[], target: string[]) => this.keysMatch(pressed as any, target);
   public testStepsMatch = (a: string[][], b: string[][]) => this.stepsMatch(a, b);
   public testIsMacPlatform = () => this.isMacPlatform();
 }


### PR DESCRIPTION
# Event Filtering

This pull request introduces a flexible and efficient event filtering system to the `ngx-keys` library, allowing developers to control when keyboard shortcuts are processed. It adds global, group-level, and per-shortcut filters, and provides a comprehensive API for managing these filters. The documentation and type definitions have been updated to reflect these enhancements, and the event processing logic has been optimized for performance and clarity.

## Event Filtering System Enhancements

- Added support for named global filters, group-level filters, and per-shortcut filters, allowing fine-grained control over when shortcuts are processed. Filters are evaluated in the order: global → group → shortcut, and all must pass for a shortcut to execute. 
- Introduced new API methods in `KeyboardShortcuts` for managing global filters: `addFilter`, `removeFilter`, `getFilter`, `getFilterNames`, `clearFilters`, and `hasFilter`.
- Added a `KeyboardShortcutFilter` type and updated the interfaces for shortcuts and groups to support optional filter functions.

## Performance and API Improvements

- Optimized event processing: global filters are now checked once per event for early exit, and group filters are precomputed to avoid redundant checks, improving performance especially when many shortcuts are registered.
- Updated the shortcut registration API to accept group options (including filters and lifecycle management) in a backward-compatible way.

## Documentation Updates

- Expanded the README with detailed examples and best practices for event filtering, including common patterns (e.g., ignoring form elements, modal context filtering), performance tips, and code samples.

## Internal Refactoring 

- Refactored internal data structures to enable O(1) lookup of a shortcut's group, and ensured proper cleanup of these mappings on unregister.
- Improved compatibility in lifecycle management by supporting duck-typed `DestroyRef` objects.

Resolves #7 