### PR TITLE
feat: Enhanced Conflict Detection

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -132,5 +132,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/projects/ngx-keys/README.md
+++ b/projects/ngx-keys/README.md
@@ -10,7 +10,8 @@ A lightweight, reactive Angular service for managing keyboard shortcuts with sig
 - **🌍 Cross-Platform**: Automatic Mac/PC key display formatting
 - **🔄 Dynamic Management**: Add, remove, activate/deactivate shortcuts at runtime
 - **📁 Group Management**: Organize shortcuts into logical groups
-- **🪶 Lightweight**: Zero dependencies, minimal bundle impact
+- **� Smart Conflict Detection**: Register multiple shortcuts with same keys when not simultaneously active
+- **�🪶 Lightweight**: Zero dependencies, minimal bundle impact
 
 ## Installation
 
@@ -122,6 +123,56 @@ this.keyboardService.register({
 });
 ```
 
+### Smart Conflict Detection
+> [!IMPORTANT]
+Conflicts are only checked among **active** shortcuts, not all registered shortcuts.
+
+ngx-keys allows registering multiple shortcuts with the same key combination, as long as they're not simultaneously active. This enables powerful patterns:
+
+- **Context-specific shortcuts**: Same keys for different UI contexts
+- **Alternative shortcuts**: Multiple ways to trigger the same action 
+- **Feature toggles**: Same keys for different modes
+
+```typescript
+// Basic conflict handling
+this.keyboardService.register(shortcut1); // Active by default
+this.keyboardService.deactivate('shortcut1'); 
+this.keyboardService.register(shortcut2); // Same keys, but shortcut1 is inactive ✅
+
+// This would fail - conflicts with active shortcut2
+// this.keyboardService.activate('shortcut1'); // ❌ Throws error
+```
+
+### Group Management
+
+Organize related shortcuts into groups for easier management:
+
+```typescript
+const editorShortcuts = [
+  {
+    id: 'bold',
+    keys: ['ctrl', 'b'],
+    macKeys: ['meta', 'b'],
+    action: () => this.makeBold(),
+    description: 'Make text bold'
+  },
+  {
+    id: 'italic', 
+    keys: ['ctrl', 'i'],
+    macKeys: ['meta', 'i'],
+    action: () => this.makeItalic(),
+    description: 'Make text italic'
+  }
+];
+
+// Register all shortcuts in the group
+this.keyboardService.registerGroup('editor', editorShortcuts);
+
+// Control the entire group
+this.keyboardService.deactivateGroup('editor'); // Disable all editor shortcuts
+this.keyboardService.activateGroup('editor');   // Re-enable all editor shortcuts
+```
+
 ### Multi-step (sequence) shortcuts
 
 In addition to single-step shortcuts using `keys` / `macKeys`, ngx-keys supports ordered multi-step sequences using `steps` and `macSteps` on the `KeyboardShortcut` object. Each element in `steps` is itself an array of key tokens that must be pressed together for that step.
@@ -138,7 +189,7 @@ this.keyboardService.register({
 });
 ```
 
-Important behavior notes:
+**Important behavior notes**
 
 - Default sequence timeout: the service requires the next step to be entered within 2000ms (2 seconds) of the previous step; otherwise the pending sequence is cleared. This timeout is intentionally conservative and can be changed in future releases or exposed per-shortcut if needed.
 - Steps are order-sensitive. `steps: [['ctrl','k'], ['s']]` is different from `steps: [['s'], ['ctrl','k']]`.
@@ -155,6 +206,155 @@ this.keyboardService.deactivate('save');
 this.keyboardService.activate('save');
 ```
 
+## Advanced Usage
+
+### Context-Specific Shortcuts
+
+Register different actions for the same keys in different UI contexts:
+
+```typescript
+// Modal context
+this.keyboardService.register({
+  id: 'modal-escape',
+  keys: ['escape'],
+  action: () => this.closeModal(),
+  description: 'Close modal'
+});
+
+// Initially deactivate since modal isn't shown
+this.keyboardService.deactivate('modal-escape');
+
+// Editor context  
+this.keyboardService.register({
+  id: 'editor-escape',
+  keys: ['escape'], // Same key, different context
+  action: () => this.exitEditMode(),
+  description: 'Exit edit mode'
+});
+
+// Switch contexts dynamically
+showModal() {
+  this.keyboardService.deactivate('editor-escape');
+  this.keyboardService.activate('modal-escape');
+}
+
+hideModal() {
+  this.keyboardService.deactivate('modal-escape');
+  this.keyboardService.activate('editor-escape');
+}
+```
+
+### Alternative Shortcuts
+
+Provide multiple ways to trigger the same functionality:
+
+```typescript
+// Primary shortcut
+this.keyboardService.register({
+  id: 'help-f1',
+  keys: ['f1'],
+  action: () => this.showHelp(),
+  description: 'Show help (F1)'
+});
+
+// Alternative shortcut - different keys, same action
+this.keyboardService.register({
+  id: 'help-ctrl-h',
+  keys: ['ctrl', 'h'],
+  action: () => this.showHelp(), // Same action
+  description: 'Show help (Ctrl+H)'
+});
+
+// Both are active simultaneously since they don't conflict
+```
+
+### Feature Toggles
+
+Switch between different modes that use the same keys:
+
+```typescript
+// Design mode
+this.keyboardService.register({
+  id: 'design-mode-space',
+  keys: ['space'],
+  action: () => this.toggleDesignElement(),
+  description: 'Toggle design element'
+});
+
+// Play mode (same key, different action)
+this.keyboardService.register({
+  id: 'play-mode-space',
+  keys: ['space'],
+  action: () => this.pausePlayback(),
+  description: 'Pause/resume playback'
+});
+
+// Initially deactivate play mode
+this.keyboardService.deactivate('play-mode-space');
+
+// Switch modes
+switchToPlayMode() {
+  this.keyboardService.deactivate('design-mode-space');
+  this.keyboardService.activate('play-mode-space');
+}
+
+switchToDesignMode() {
+  this.keyboardService.deactivate('play-mode-space');
+  this.keyboardService.activate('design-mode-space');
+}
+```
+
+### Advanced Group Patterns
+
+Use groups for complex activation/deactivation scenarios:
+
+```typescript
+// Create context-specific groups
+const modalShortcuts = [
+  { id: 'modal-close', keys: ['escape'], action: () => this.closeModal(), description: 'Close modal' },
+  { id: 'modal-confirm', keys: ['enter'], action: () => this.confirmModal(), description: 'Confirm' }
+];
+
+const editorShortcuts = [
+  { id: 'editor-save', keys: ['ctrl', 's'], action: () => this.save(), description: 'Save' },
+  { id: 'editor-undo', keys: ['ctrl', 'z'], action: () => this.undo(), description: 'Undo' }
+];
+
+// Register both groups
+this.keyboardService.registerGroup('modal', modalShortcuts);
+this.keyboardService.registerGroup('editor', editorShortcuts);
+
+// Initially only editor is active
+this.keyboardService.deactivateGroup('modal');
+
+// Switch contexts
+showModal() {
+  this.keyboardService.deactivateGroup('editor');
+  this.keyboardService.activateGroup('modal');
+}
+
+hideModal() {
+  this.keyboardService.deactivateGroup('modal');
+  this.keyboardService.activateGroup('editor');
+}
+```
+
+### Conflict Detection Rules
+
+- **Registration**: Only checks conflicts with currently **active** shortcuts
+- **Activation**: Throws error if activating would conflict with other active shortcuts
+- **Groups**: Same rules apply - groups can contain conflicting shortcuts as long as they're not simultaneously active
+
+```typescript
+// ✅ This works - shortcuts with same keys but only one active at a time
+this.keyboardService.register(shortcut1); // Active by default
+this.keyboardService.deactivate('shortcut1'); 
+this.keyboardService.register(shortcut2); // Same keys, but shortcut1 is inactive
+
+// ❌ This fails - trying to activate would create conflict
+this.keyboardService.activate('shortcut1'); // Throws error - conflicts with active shortcut2
+```
+
 ## API Reference
 
 ### KeyboardShortcuts Service
@@ -162,15 +362,18 @@ this.keyboardService.activate('save');
 #### Methods
 
 **Registration Methods:**
-- `register(shortcut: KeyboardShortcut)` - Register and automatically activate a single shortcut *Throws error on conflicts*
-- `registerGroup(groupId: string, shortcuts: KeyboardShortcut[])` - Register and automatically activate a group of shortcuts *Throws error on conflicts*
+> [!TIP]
+Conflicts are only checked among **active** shortcuts, not all registered shortcuts.
+
+- `register(shortcut: KeyboardShortcut)` - Register and automatically activate a single shortcut *Throws error on conflicts with active shortcuts only*
+- `registerGroup(groupId: string, shortcuts: KeyboardShortcut[])` - Register and automatically activate a group of shortcuts *Throws error on conflicts with active shortcuts only*
 
 **Management Methods:**
 - `unregister(shortcutId: string)` - Remove a shortcut *Throws error if not found*
 - `unregisterGroup(groupId: string)` - Remove a group *Throws error if not found*
-- `activate(shortcutId: string)` - Activate a shortcut *Throws error if not registered*
+- `activate(shortcutId: string)` - Activate a shortcut *Throws error if not registered or would create conflicts*
 - `deactivate(shortcutId: string)` - Deactivate a shortcut *Throws error if not registered*
-- `activateGroup(groupId: string)` - Activate all shortcuts in a group *Throws error if not found*
+- `activateGroup(groupId: string)` - Activate all shortcuts in a group *Throws error if not found or would create conflicts*
 - `deactivateGroup(groupId: string)` - Deactivate all shortcuts in a group *Throws error if not found*
 
 **Query Methods:**

--- a/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcut.interface.ts
@@ -10,6 +10,14 @@ export interface KeyboardShortcut {
   /**
    * Single-step shortcuts keep the existing shape using `keys`/`macKeys`.
    * For multi-step shortcuts, use `steps` (array of steps), where each step is an array of keys.
+   * 
+   * The library allows registering multiple shortcuts with the same 
+   * key combination as long as they are not simultaneously active. This enables:
+   * - Context-specific shortcuts (e.g., same key in different UI contexts)
+   * - Alternative shortcuts for the same action 
+   * - Feature toggles with same keys for different modes
+   * 
+   * Conflicts are only checked among active shortcuts, not all registered shortcuts.
    */
   keys?: string[];
   macKeys?: string[];

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.errors.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.errors.ts
@@ -7,6 +7,9 @@ export const KeyboardShortcutsErrors = {
   SHORTCUT_ALREADY_REGISTERED: (id: string) => `Shortcut "${id}" already registered`,
   GROUP_ALREADY_REGISTERED: (id: string) => `Group "${id}" already registered`,
   KEY_CONFLICT: (conflictId: string) => `Key conflict with "${conflictId}"`,
+  ACTIVE_KEY_CONFLICT: (conflictId: string) => `Key conflict with active shortcut "${conflictId}"`,
+  ACTIVATION_KEY_CONFLICT: (shortcutId: string, conflictIds: string[]) => `Cannot activate "${shortcutId}": would conflict with active shortcuts: ${conflictIds.join(', ')}`,
+  GROUP_ACTIVATION_KEY_CONFLICT: (groupId: string, conflictIds: string[]) => `Cannot activate group "${groupId}": would conflict with active shortcuts: ${conflictIds.join(', ')}`,
   SHORTCUT_IDS_ALREADY_REGISTERED: (ids: string[]) => `Shortcut IDs already registered: ${ids.join(', ')}`,
   DUPLICATE_SHORTCUTS_IN_GROUP: (ids: string[]) => `Duplicate shortcuts in group: ${ids.join(', ')}`,
   KEY_CONFLICTS_IN_GROUP: (conflicts: string[]) => `Key conflicts: ${conflicts.join(', ')}`,
@@ -70,6 +73,30 @@ export class KeyboardShortcutsErrorFactory {
       'KEY_CONFLICT',
       KeyboardShortcutsErrors.KEY_CONFLICT(conflictId),
       { conflictId }
+    );
+  }
+
+  static activeKeyConflict(conflictId: string): KeyboardShortcutError {
+    return new KeyboardShortcutError(
+      'ACTIVE_KEY_CONFLICT',
+      KeyboardShortcutsErrors.ACTIVE_KEY_CONFLICT(conflictId),
+      { conflictId }
+    );
+  }
+
+  static activationKeyConflict(shortcutId: string, conflictIds: string[]): KeyboardShortcutError {
+    return new KeyboardShortcutError(
+      'ACTIVATION_KEY_CONFLICT',
+      KeyboardShortcutsErrors.ACTIVATION_KEY_CONFLICT(shortcutId, conflictIds),
+      { shortcutId, conflictIds }
+    );
+  }
+
+  static groupActivationKeyConflict(groupId: string, conflictIds: string[]): KeyboardShortcutError {
+    return new KeyboardShortcutError(
+      'GROUP_ACTIVATION_KEY_CONFLICT',
+      KeyboardShortcutsErrors.GROUP_ACTIVATION_KEY_CONFLICT(groupId, conflictIds),
+      { groupId, conflictIds }
     );
   }
 

--- a/projects/ngx-keys/src/lib/keyboard-shortcuts.ts
+++ b/projects/ngx-keys/src/lib/keyboard-shortcuts.ts
@@ -168,11 +168,16 @@ export class KeyboardShortcuts implements OnDestroy {
   }
 
   /**
-   * Check if a key combination is already registered
-   * @returns The ID of the conflicting shortcut, or null if no conflict
+   * Check if a key combination is already registered by an active shortcut
+   * @returns The ID of the conflicting active shortcut, or null if no active conflict
    */
-  private findConflict(newShortcut: KeyboardShortcut): string | null {
+  private findActiveConflict(newShortcut: KeyboardShortcut): string | null {
     for (const existing of this.shortcuts.values()) {
+      // Only check conflicts with active shortcuts
+      if (!this.activeShortcuts.has(existing.id)) {
+        continue;
+      }
+
       // Compare single-step shapes if provided
       if (newShortcut.keys && existing.keys && this.keysMatch(newShortcut.keys, existing.keys)) {
         return existing.id;
@@ -193,17 +198,44 @@ export class KeyboardShortcuts implements OnDestroy {
   }
 
   /**
+   * Check if activating a shortcut would create key conflicts with other active shortcuts
+   * @returns Array of conflicting shortcut IDs that would be created by activation
+   */
+  private findActivationConflicts(shortcutId: string): string[] {
+    const shortcut = this.shortcuts.get(shortcutId);
+    if (!shortcut) return [];
+
+    const conflicts: string[] = [];
+    for (const existing of this.shortcuts.values()) {
+      // Skip self and inactive shortcuts
+      if (existing.id === shortcutId || !this.activeShortcuts.has(existing.id)) {
+        continue;
+      }
+
+      // Check for key conflicts
+      if ((shortcut.keys && existing.keys && this.keysMatch(shortcut.keys, existing.keys)) ||
+          (shortcut.macKeys && existing.macKeys && this.keysMatch(shortcut.macKeys, existing.macKeys)) ||
+          (shortcut.steps && existing.steps && this.stepsMatch(shortcut.steps, existing.steps)) ||
+          (shortcut.macSteps && existing.macSteps && this.stepsMatch(shortcut.macSteps, existing.macSteps))) {
+        conflicts.push(existing.id);
+      }
+    }
+    return conflicts;
+  }
+
+  /**
    * Register a single keyboard shortcut
-   * @throws KeyboardShortcutError if shortcut ID is already registered or key combination is in use
+   * @throws KeyboardShortcutError if shortcut ID is already registered or if the shortcut would conflict with currently active shortcuts
    */
   register(shortcut: KeyboardShortcut): void {
     if (this.shortcuts.has(shortcut.id)) {
       throw KeyboardShortcutsErrorFactory.shortcutAlreadyRegistered(shortcut.id);
     }
 
-    const conflictId = this.findConflict(shortcut);
+    // Check for conflicts only with currently active shortcuts
+    const conflictId = this.findActiveConflict(shortcut);
     if (conflictId) {
-      throw KeyboardShortcutsErrorFactory.keyConflict(conflictId);
+      throw KeyboardShortcutsErrorFactory.activeKeyConflict(conflictId);
     }
     
     this.shortcuts.set(shortcut.id, shortcut);
@@ -226,16 +258,16 @@ export class KeyboardShortcuts implements OnDestroy {
       throw KeyboardShortcutsErrorFactory.groupAlreadyRegistered(groupId);
     }
     
-    // Check for duplicate shortcut IDs and key combination conflicts
+    // Check for duplicate shortcut IDs and key combination conflicts with active shortcuts
     const duplicateIds: string[] = [];
     const keyConflicts: string[] = [];
     shortcuts.forEach(shortcut => {
       if (this.shortcuts.has(shortcut.id)) {
         duplicateIds.push(shortcut.id);
       }
-      const conflictId = this.findConflict(shortcut);
+      const conflictId = this.findActiveConflict(shortcut);
       if (conflictId) {
-        keyConflicts.push(`"${shortcut.id}" conflicts with "${conflictId}"`);
+        keyConflicts.push(`"${shortcut.id}" conflicts with active shortcut "${conflictId}"`);
       }
     });
     
@@ -322,11 +354,17 @@ export class KeyboardShortcuts implements OnDestroy {
 
   /**
    * Activate a single keyboard shortcut
-   * @throws KeyboardShortcutError if shortcut ID doesn't exist
+   * @throws KeyboardShortcutError if shortcut ID doesn't exist or if activation would create key conflicts
    */
   activate(shortcutId: string): void {
     if (!this.shortcuts.has(shortcutId)) {
       throw KeyboardShortcutsErrorFactory.cannotActivateShortcut(shortcutId);
+    }
+
+    // Check for conflicts that would be created by activation
+    const conflicts = this.findActivationConflicts(shortcutId);
+    if (conflicts.length > 0) {
+      throw KeyboardShortcutsErrorFactory.activationKeyConflict(shortcutId, conflicts);
     }
     
     this.activeShortcuts.add(shortcutId);
@@ -348,12 +386,23 @@ export class KeyboardShortcuts implements OnDestroy {
 
   /**
    * Activate a group of keyboard shortcuts
-   * @throws KeyboardShortcutError if group ID doesn't exist
+   * @throws KeyboardShortcutError if group ID doesn't exist or if activation would create key conflicts
    */
   activateGroup(groupId: string): void {
     const group = this.groups.get(groupId);
     if (!group) {
       throw KeyboardShortcutsErrorFactory.cannotActivateGroup(groupId);
+    }
+
+    // Check for conflicts that would be created by activating all shortcuts in the group
+    const allConflicts: string[] = [];
+    group.shortcuts.forEach(shortcut => {
+      const conflicts = this.findActivationConflicts(shortcut.id);
+      allConflicts.push(...conflicts);
+    });
+
+    if (allConflicts.length > 0) {
+      throw KeyboardShortcutsErrorFactory.groupActivationKeyConflict(groupId, allConflicts);
     }
     
     this.batchUpdate(() => {


### PR DESCRIPTION
This pull request introduces advanced conflict detection and activation logic to the `ngx-keys` Angular keyboard shortcut library. The changes allow multiple shortcuts with the same key combinations to be registered, as long as they are not simultaneously active, enabling context-specific, alternative, and feature toggle patterns. 

The documentation, error handling, and test suite have all been updated to reflect and enforce these new behaviors.

* Shortcuts with the same keys can now be registered as long as only one is active at a time, supporting context-specific, alternative, and feature-toggle use cases. Conflicts are only checked among active shortcuts, both at registration and activation time.
* New error messages and error factory methods clearly distinguish between registration, activation, and group activation conflicts, improving developer feedback.

## Test Suite Enhancements

Consider the Test Suite as a work in progress; tests added here are intended to prevent breaking changes at the expense of exposing private methods solely for testing.

  - Shortcuts with the same keys can be registered if only one is active.
  - Activation of a shortcut or group that would create a conflict throws an appropriate error.
  - Common patterns like context switching, feature toggles, and alternative shortcuts are supported and work as intended. 



* Disables Angular CLI analytics in `angular.json` for privacy and consistency.