### PR TITLE
hotfix: Multi-step shortcuts resolve conflicts with single-step shortcuts

### DIFF
--- a/projects/demo/src/app/directive-demo/directive-demo.component.html
+++ b/projects/demo/src/app/directive-demo/directive-demo.component.html
@@ -1,11 +1,11 @@
 <h2>Directive Demo</h2>
-<p>Use the <code>ngxKeyboardShortcut</code> directive to configure shortcuts directly in templates.</p>
+<p>Use the <code>ngxKeys</code> directive to configure shortcuts directly in templates.</p>
 
 <p><strong>Recent Action:</strong> {{ lastAction }}</p>
 
 <section class="controls">
   <button 
-    ngxKeyboardShortcut
+    ngxKeys
     keys="ctrl,s"
     macKeys="cmd,s"
     description="Save document"
@@ -14,7 +14,7 @@
   </button>
   
   <button 
-    ngxKeyboardShortcut
+    ngxKeys
     keys="delete"
     description="Delete item"
     (click)="onDelete()">
@@ -22,7 +22,7 @@
   </button>
   
   <button 
-    ngxKeyboardShortcut
+    ngxKeys
     keys="?"
     description="Toggle help"
     [action]="toggleHelp">
@@ -30,7 +30,7 @@
   </button>
   
   <button 
-    ngxKeyboardShortcut
+    ngxKeys
     [steps]="[['ctrl', 'g'], ['ctrl', 'd']]"
     description="Format document"
     (click)="onFormatDocument()">
@@ -52,7 +52,7 @@
   <section>
     <fieldset>
       <legend>Help Panel</legend>
-      <p>The <code>ngxKeyboardShortcut</code> directive automatically:</p>
+      <p>The <code>ngxKeys</code> directive automatically:</p>
       <ul>
         <li>Registers shortcuts when initialized</li>
         <li>Triggers click events or custom actions</li>

--- a/projects/ngx-keys/package.json
+++ b/projects/ngx-keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-keys",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A reactive Angular library for managing keyboard shortcuts with signals-based UI integration",
   "keywords": [
     "angular",

--- a/projects/ngx-keys/src/lib/core/keyboard-shortcuts.service.spec.ts
+++ b/projects/ngx-keys/src/lib/core/keyboard-shortcuts.service.spec.ts
@@ -1014,6 +1014,52 @@ describe('KeyboardShortcuts', () => {
         );
       });
 
+      it('should throw error when registering single-step shortcut that conflicts with first step of multi-step shortcut', () => {
+        // Register a multi-step shortcut first (Ctrl+K, then S)
+        const multiStepShortcut = createMockShortcut({
+          id: 'multi-step-save',
+          steps: [['ctrl', 'k'], ['s']],
+          action: () => {},
+          description: 'Multi-step save',
+        });
+        service.register(multiStepShortcut);
+
+        // Try to register a single-step shortcut with the same keys as the first step
+        const conflictingShortcut = createMockShortcut({
+          id: 'single-step-conflict',
+          keys: ['ctrl', 'k'],
+          action: () => {},
+          description: 'Conflicting shortcut',
+        });
+
+        expect(() => service.register(conflictingShortcut)).toThrowError(
+          KeyboardShortcutsErrors.ACTIVE_KEY_CONFLICT('multi-step-save')
+        );
+      });
+
+      it('should throw error when registering multi-step shortcut whose first step conflicts with single-step shortcut', () => {
+        // Register a single-step shortcut first
+        const singleStepShortcut = createMockShortcut({
+          id: 'single-step-action',
+          keys: ['ctrl', 'k'],
+          action: () => {},
+          description: 'Single step action',
+        });
+        service.register(singleStepShortcut);
+
+        // Try to register a multi-step shortcut whose first step conflicts
+        const conflictingMultiStep = createMockShortcut({
+          id: 'multi-step-conflict',
+          steps: [['ctrl', 'k'], ['s']],
+          action: () => {},
+          description: 'Multi-step conflict',
+        });
+
+        expect(() => service.register(conflictingMultiStep)).toThrowError(
+          KeyboardShortcutsErrors.ACTIVE_KEY_CONFLICT('single-step-action')
+        );
+      });
+
       it('should allow registering shortcuts with same keys when original is inactive', () => {
         service.register({ ...mockShortcut, id: 'shortcut-1' });
         service.deactivate('shortcut-1'); // Make it inactive


### PR DESCRIPTION
Introduces improvements to the keyboard shortcut conflict detection logic in the `ngx-keys` library, ensuring that single-step and multi-step shortcuts cannot be registered if their key sequences overlap in a way that would cause ambiguous behavior. It also updates the demo and bumps the package version.

* Enhanced the conflict detection logic in `KeyboardShortcuts` to prevent registration of single-step shortcuts that conflict with the first step of an existing multi-step shortcut, and vice versa. This prevents ambiguous shortcut activation.
* Updated the `findConflictingShortcutId` and `getConflictingShortcutIds` methods to check for these new types of conflicts and to use a `Set` for collecting conflicts, avoiding duplicates.
* Added new unit tests to verify that registering conflicting shortcuts throws the appropriate errors, covering both single-step and multi-step scenarios.
* Updated the demo component and documentation to use the renamed `ngxKeys` directive instead of the old `ngxKeyboardShortcut` directive, reflecting the current API. 
* Incremented the package version from `1.3.0` to `1.3.1` to reflect these changes. (`projects/ngx-keys/package.json`)